### PR TITLE
Fix pitcher stat extraction in parsePitcher

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -242,9 +242,10 @@ async function loadAll(force=false){
         const pp = g.teams?.[side]?.probablePitcher;
         if (!pp) return null;
         const stats = pp?.stats?.find(s=>s.group?.displayName==='pitching' && s.type?.displayName==='season');
-        const era = stats?.stats?.era;
-        const wins = stats?.stats?.wins;
-        const losses = stats?.stats?.losses;
+        const statLine = stats?.splits?.[0]?.stat;
+        const era = statLine?.era;
+        const wins = statLine?.wins;
+        const losses = statLine?.losses;
         return { name: pp.fullName, era, wins, losses };
       }
       const hp = parsePitcher('home');


### PR DESCRIPTION
## Summary
- read pitcher ERA/W/L from the first splits stat entry when parsing probable pitchers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1c52713ec83298e487733c731cb50